### PR TITLE
Update dependencies and add pip check

### DIFF
--- a/.ci_support/linux_64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_python3.6.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,5 +17,3 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_python3.7.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,5 +17,3 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,5 +17,3 @@ target_platform:
 zip_keys:
 - - cdt_name
   - docker_image
-- - python
-  - numpy

--- a/.ci_support/osx_64_python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_python3.6.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -16,6 +14,3 @@ python:
 - 3.6.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - numpy

--- a/.ci_support/osx_64_python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_python3.7.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -16,6 +14,3 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - numpy

--- a/.ci_support/osx_64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_python3.8.____cpython.yaml
@@ -6,8 +6,6 @@ channel_targets:
 - conda-forge main
 macos_machine:
 - x86_64-apple-darwin13.4.0
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -16,6 +14,3 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - osx-64
-zip_keys:
-- - python
-  - numpy

--- a/.ci_support/win_64_python3.7.____cpython.yaml
+++ b/.ci_support/win_64_python3.7.____cpython.yaml
@@ -2,8 +2,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -12,6 +10,3 @@ python:
 - 3.7.* *_cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - numpy

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -2,8 +2,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-numpy:
-- '1.17'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -12,6 +10,3 @@ python:
 - 3.8.* *_cpython
 target_platform:
 - win-64
-zip_keys:
-- - python
-  - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3e682e8ea6e1ee26a92cf289f207d539f30e44879126c128ff8f4e360eb25a8b
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win and py<37]
   script: "{{ PYTHON }} -m pip install . -vv"
   binary_has_prefix_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,34 +20,49 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    # Explanation:
+    #
+    # setup.py imports fbprophet.models.StanBackendEnum, triggering
+    # fbprophet/__init__.py and thus making the runtime dependencies
+    # also build-time dependencies.
+    - python
+    - cython >=0.22
+    - cmdstanpy ==0.9.68
+    - pystan ~=2.19.1.1
+    - numpy >=1.15.4
     - pandas >=1.0.4
-    - pystan ==2.19.1.1
-    - LunarCalendar
-    - convertdate
+    - matplotlib-base >=2.0.0
+    - LunarCalendar >=0.0.9
+    - convertdate >=2.1.2
     - holidays >=0.10.2
-    - python-dateutil
-    - tqdm
-    - numpy
+    - setuptools-git >=1.2
+    - python-dateutil >=2.8.0
+    - tqdm >=4.36.1
   run:
     - python
-    - setuptools
-    - matplotlib-base
+    - cython >=0.22
+    - cmdstanpy ==0.9.68
+    - pystan ~=2.19.1.1
+    - numpy >=1.15.4
     - pandas >=1.0.4
-    - pystan ==2.19.1.1
-    - LunarCalendar
-    - convertdate
+    - matplotlib-base >=2.0.0
+    - LunarCalendar >=0.0.9
+    - convertdate >=2.1.2
     - holidays >=0.10.2
-    - python-dateutil
-    - tqdm
-    - {{ pin_compatible('numpy') }}
+    - setuptools-git >=1.2
+    - python-dateutil >=2.8.0
+    - tqdm >=4.36.1
 
 test:
-  requires:
-    - pytest
-
+  imports:
+    - prophet
+    - prophet.tests
   commands:
+    - pip check
     - py.test -v --pyargs prophet
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://facebook.github.io/prophet/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,6 @@ requirements:
     - cython >=0.22
     - cmdstanpy ==0.9.68
     - pystan ~=2.19.1.1
-    - numpy >=1.15.4
     - pandas >=1.0.4
     - matplotlib-base >=2.0.0
     - LunarCalendar >=0.0.9
@@ -53,6 +52,7 @@ requirements:
     - setuptools-git >=1.2
     - python-dateutil >=2.8.0
     - tqdm >=4.36.1
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     # setup.py imports fbprophet.models.StanBackendEnum, triggering
     # fbprophet/__init__.py and thus making the runtime dependencies
     # also build-time dependencies.
-    - python
+    #
+    # These requirements are copied from python/requirements.txt
     - cython >=0.22
     - cmdstanpy ==0.9.68
     - pystan ~=2.19.1.1


### PR DESCRIPTION
This adds the missing dependencies `setuptools-git` and `cmdstanpy`. (I recently created the feedstock for `cmdstanpy` to accomplish this.)

Now pip is consistent, and `pip check` can be added as a successful test.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
